### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./.output/public
+          path: ./app/.output/public
   # Deployment job
   deploy:
     # Add a dependency to the build job


### PR DESCRIPTION
# 概要
- .outputディレクトリの参照先をrootから./appに変更